### PR TITLE
feat: use pino logging on dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "logger",
-  "version": "0.1.0",
+  "name": "@heyatlas/logger",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "logger",
-      "version": "0.1.0",
-      "license": "ISC",
+      "name": "@heyatlas/logger",
+      "version": "1.4.4",
+      "license": "MIT",
       "dependencies": {
         "@slack/web-api": "^7.8.0",
         "@slack/webhook": "^7.0.4",

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -87,12 +87,13 @@ export class Logger {
     streams: StreamConfig[];
   }): bunyan {
     const streams: bunyan.Stream[] = config.streams.map((streamConfig) => {
+      const env = process.env.NODE_ENV || 'local'
       switch (streamConfig.type) {
         case "stdout":
           return {
             level: streamConfig.level,
             stream:
-              process.env.NODE_ENV === "test" ? prettyStream : process.stdout,
+              ['local', 'test'].includes(env) ? prettyStream : process.stdout,
           };
         case "file":
           if (!streamConfig.path) {


### PR DESCRIPTION
As discussed on https://github.com/heyatlas/api/pull/167

Tested:
<img width="629" height="96" alt="image" src="https://github.com/user-attachments/assets/7e7bc7c2-3704-43e9-b964-ab2cf075f734" />
